### PR TITLE
fix: force system clock to be set on linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const setTimezone = async () => {
     switch (platform) {
       case "linux":
         const timezone = core.getInput("timezoneLinux");
-        await execCommand("sudo", ["timedatectl", "set-timezone", timezone]);
+        await execCommand("sudo", ["timedatectl", "set-timezone", timezone, "--adjust-system-clock --no-ask-password"]);
         break;
       case "darwin":
         const timezone = core.getInput("timezoneMacos");
@@ -33,3 +33,4 @@ const setTimezone = async () => {
 };
 
 setTimezone();
+


### PR DESCRIPTION
after checking the time in a pipeline via 'date' the zone was not adjusted accordingly. set-system-time solves this issue.