### PR TITLE
Announce to use v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action sets timezone in your runner's locale based on its OS.
 ## Example usage
 
 ```yaml
-uses: szenius/set-timezone@v1.0
+uses: szenius/set-timezone@v1.1
 with:
   timezoneLinux: "Asia/Singapore"
   timezoneMacos: "Asia/Singapore"


### PR DESCRIPTION
I want you to announce to use v1.1 in README because a warning message like below shows up with using v1.0 and current README announces to use v1.0.

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: szenius/set-timezone@v1.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```